### PR TITLE
Produce unique tile list

### DIFF
--- a/nginx/tile_multiplier.py
+++ b/nginx/tile_multiplier.py
@@ -3,15 +3,23 @@
 import sys
 
 min_zoom, max_zoom = [int(z) for z in sys.argv[1:3]]
+tile_set = set()
+
+def print_once(x, y, z):
+    tile = '{}/{}/{}'.format(z, x, y)
+    num_tiles = len(tile_set)
+    tile_set.add(tile)
+    if num_tiles < len(tile_set):
+        print tile
 
 for line in sys.stdin:
     z, x, y = [int(i) for i in line.split('/')]
-    print('{}/{}/{}'.format(z, x, y))
+    print_once(z, x, y)
 
     xx, yy = x, y
     for zz in range(z - 1, min_zoom - 1, -1):
         xx, yy = xx // 2, yy // 2
-        print('{}/{}/{}'.format(zz, xx, yy))
+        print_once(zz, xx, yy)
 
     xx, yy = x, y
     s = 1
@@ -20,4 +28,4 @@ for line in sys.stdin:
         s *= 2
         for sx in range(0, s):
             for sy in range(0, s):
-                print('{}/{}/{}'.format(zz, xx+sx, yy+sy))
+                print_once(zz, xx+sx, yy+sy)

--- a/nginx/tile_multiplier.py
+++ b/nginx/tile_multiplier.py
@@ -5,12 +5,13 @@ import sys
 min_zoom, max_zoom = [int(z) for z in sys.argv[1:3]]
 tile_set = set()
 
-def print_once(x, y, z):
-    tile = '{}/{}/{}'.format(z, x, y)
-    num_tiles = len(tile_set)
-    tile_set.add(tile)
-    if num_tiles < len(tile_set):
-        print tile
+def print_once(z, x, y):
+    if min_zoom <= z <= max_zoom:
+        tile = '{}/{}/{}'.format(z, x, y)
+        num_tiles = len(tile_set)
+        tile_set.add(tile)
+        if num_tiles < len(tile_set):
+            print tile
 
 for line in sys.stdin:
     z, x, y = [int(i) for i in line.split('/')]


### PR DESCRIPTION
When a list of tiles is used by `tilelive-copy`, all tiles are read, including duplicate entries.
To reduce the unnecessary read operation, especially in lower zoom levels, a `print_once` method is introduced and the output list includes unique values.

For example, using `tile_multiplier.py 0 14` with 1208 lines, with the original code produced 15x1208=18120 lines and the new code produced 2076 unique lines. This is more than 8x reduction.