### PR TITLE
change naming to create network policies more easily with kompose

### DIFF
--- a/docker-compose-benchmark.yml
+++ b/docker-compose-benchmark.yml
@@ -11,7 +11,7 @@ services:
       - graphite_configs:/opt/graphite/conf
       - graphite_data:/opt/graphite/storage
     networks:
-      - openmaptiles_conn
+      - openmaptiles-conn
     ports:
       - "8899:80"
 
@@ -21,4 +21,4 @@ services:
     volumes:
       - ./artillery:/artillery
     networks:
-      - openmaptiles_conn
+      - openmaptiles-conn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./tileserver-gl/static/public/index.html:/usr/src/app/public/templates/index.tmpl
       - ./tileserver-gl/static/public:/usr/src/app/public/resources
     networks:
-      - openmaptiles_conn
+      - openmaptiles-conn
 
   nginx:
     build:
@@ -23,14 +23,14 @@ services:
       - nginx-cache:/cache
       - ./openmaptiles/data/expire_tiles:/data/expire_tiles
     networks:
-      - openmaptiles_conn
+      - openmaptiles-conn
     ports:
       - "${NGINX_PORT:-8080}:80"
       - "127.0.0.1:8082:82"
 
 networks:
-  openmaptiles_conn:
-    name: openmaptiles_postgres_conn
+  openmaptiles-conn:
+    name: openmaptiles-postgres-conn
     driver: bridge
 
 volumes:


### PR DESCRIPTION
[Kompose](https://kompose.io/) is a tool that aims to create Kubernetes objects from a docker-compose definition.
network are translated to network policies. But they have to be a valid subdomain DNS name. In particular, they can't contain `_`.
Feel free to install kompose and run it on the docker-compose to see