### PR TITLE
Fix Readme: Accessing 0.0.0.0 produces CORS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ cd openmaptiles && docker-compose up -d postgres postserve && cd ..
 docker-compose up
 ```
 
-Access to cached tiles and services at:
+Access to cached tiles and services at the following URLs - assuming your are hosting locally:
 
-* Demo: http://0.0.0.0:8080
-* OpenMapTiles TileJson: http://0.0.0.0:8080/data/v3.json
-* Default "Bright" GL JSON Style: http://0.0.0.0:8080/styles/bright/style.json
+* Demo: http://127.0.0.1:8080
+* OpenMapTiles TileJson: http://127.0.0.1:8080/data/v3.json
+* Default "Bright" GL JSON Style: http://127.0.0.1:8080/styles/bright/style.json
 * Default "Bright" raster:
-  * TileJSON: http://0.0.0.0:8080/styles/bright.json
-  * Raster tiles: http://0.0.0.0:8080/styles/bright/{z}/{x}/{y}.png
+  * TileJSON: http://127.0.0.1:8080/styles/bright.json
+  * Raster tiles: http://127.0.0.1:8080/styles/bright/{z}/{x}/{y}.png
 
 ## Configuration
 


### PR DESCRIPTION
In Recent Chrome Versions (tested with 98), accessing http://0.0.0.0:8080 loads the Demo Page but tiles are not loaded due to CORS errors. This is a bit confusing and might create the wrong impression that the tile server is not working.