### PR TITLE
#59 Make raster tiles work without config changes

### DIFF
--- a/tileserver-gl/config.json
+++ b/tileserver-gl/config.json
@@ -38,7 +38,7 @@
       "remote_tilejson": "http://postserve:8090/",
       "tilejson": {
         "tiles": [
-          "http://localhost:8080/data/v3/{z}/{x}/{y}.pbf"
+          "http://nginx/data/v3/{z}/{x}/{y}.pbf"
         ]
       }
     }


### PR DESCRIPTION
This makes raster tiles work (at least locally) without config changes.
When moving to a public reachable server, the instructions in the README might still apply.